### PR TITLE
fix: bump pytest to 9.0.3 (GHSA-6w46-j5rx-g56g)

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -2333,14 +2333,14 @@ files = [
 
 [[package]]
 name = "pytest"
-version = "9.0.2"
+version = "9.0.3"
 description = "pytest: simple powerful testing with Python"
 optional = false
 python-versions = ">=3.10"
 groups = ["dev"]
 files = [
-    {file = "pytest-9.0.2-py3-none-any.whl", hash = "sha256:711ffd45bf766d5264d487b917733b453d917afd2b0ad65223959f59089f875b"},
-    {file = "pytest-9.0.2.tar.gz", hash = "sha256:75186651a92bd89611d1d9fc20f0b4345fd827c41ccd5c299a868a05d70edf11"},
+    {file = "pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9"},
+    {file = "pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c"},
 ]
 
 [package.dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,7 @@ license = "Apache-2.0"
 name = "concepttordf"
 readme = "README.md"
 repository = "https://github.com/Informasjonsforvaltning/concepttordf"
-version = "3.1.1"
+version = "3.1.2"
 
 [tool.poetry.dependencies]
 python = ">=3.12,<3.13"


### PR DESCRIPTION
# Summary

- Bump pytest 9.0.2 → 9.0.3 to resolve moderate CVE GHSA-6w46-j5rx-g56g (vulnerable tmpdir handling)
- Bump package version 3.1.1 → 3.1.2